### PR TITLE
ci: Deploy cooking-api to EKS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/manifest
+**/target
+tests
+**/*.md
+**/.git
+**/.github
+**/node_modules
+**/.venv
+data

--- a/.github/workflows/deploy_to_aws.yml
+++ b/.github/workflows/deploy_to_aws.yml
@@ -16,15 +16,26 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::763348989563:role/GitHubActionsEKSRole
           aws-region: us-east-1
-
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        run: |
+          aws ecr-public get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin public.ecr.aws
+      - name: Build, Tag, and Push Image
+        env:
+          IMAGE_TAG: ${GITHUB_SHA::7}
+        run: |
+          docker build -t cooking-api:latest -f backend_rust/Dockerfile .
+          docker tag cooking-api:latest public.ecr.aws/v1n4z9j4/process-pj/cooking-api
+          docker push public.ecr.aws/v1n4z9j4/process-pj/cooking-api
       - name: Deploy to EKS
         working-directory: backend_rust
         run: |
           aws eks update-kubeconfig --name process-pj --region us-east-1
           kubectl apply -f manifest/dev/namespace.yaml
+          kubectl apply -f manifest/deployment.yaml

--- a/backend_rust/.dockerignore
+++ b/backend_rust/.dockerignore
@@ -1,0 +1,4 @@
+manifest
+**target
+tests
+**/*.md

--- a/backend_rust/Cargo.toml
+++ b/backend_rust/Cargo.toml
@@ -32,7 +32,6 @@ tokio-stream = "0.1.17"
 tonic-prost-build = "0.14"
 tonic-prost = "0.14"
 testcontainers-modules = { version = "0.13.0", features = ["mysql", "blocking"] }
-migration = { path = "../migration" }
 
 [build-dependencies]
 tonic-prost-build = "0.14"
@@ -41,6 +40,7 @@ tonic-prost-build = "0.14"
 [dev-dependencies]
 async-std = { version = "1.12", features = ["attributes"] }
 mockall = "0.13.1"
+migration = { path = "../migration" }
 
 [[bin]]
 name = "grpc_build"

--- a/backend_rust/Dockerfile
+++ b/backend_rust/Dockerfile
@@ -7,8 +7,10 @@ RUN apt-get update && apt-get upgrade -y \
   && apt-get install -y protobuf-compiler libprotobuf-dev
 
 # todo:  copy only files needed to build
+COPY ../Cargo.toml ../Cargo.lock ./
+COPY ../migration ../migration
 COPY . .
-RUN cargo build --release
+RUN cargo build --bin cpp-backend --release
 
 FROM debian:bullseye-slim
 COPY --from=build-stage /cpp-backend/target/release/cpp-backend /

--- a/backend_rust/manifest/deployment.yaml
+++ b/backend_rust/manifest/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-rust
+  namespace: dev-cooking-api
+  labels:
+    app: backend-rust
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend-rust
+  template:
+    metadata:
+      labels:
+        app: backend-rust
+    spec:
+      containers:
+        - name: backend-rust
+          image: public.ecr.aws/v1n4z9j4/process-pj/cooking-api:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+

--- a/backend_rust/manifest/service.yaml
+++ b/backend_rust/manifest/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-rust
+  namespace: dev-cooking-api
+  labels:
+    app: backend-rust
+spec:
+  selector:
+    app: backend-rust
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP
+


### PR DESCRIPTION
- **chore: Build docker image from repository root**
- **ci: Deploy cooking-api to EKS**
[skip ci]
### Content

### Differences

### References
[Pushing an image to a public repository in Amazon ECR public](https://docs.aws.amazon.com/AmazonECR/latest/public/docker-push-ecr-image.html)
### Tests
